### PR TITLE
libglvnd 1.7.0

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -23,13 +23,3 @@ meson setup builddir \
 
 ninja -v -C builddir
 ninja -C builddir install
-
-# Verify libraries were built and manually copy if needed
-mkdir -p ${PREFIX}/lib
-for lib in libGLX.so libOpenGL.so libGL.so libEGL.so libGLESv1_CM.so libGLESv2.so libGLdispatch.so; do
-    find builddir -name "${lib}*" -exec ls -la {} \;
-    find builddir -name "${lib}.*" -exec cp -av {} ${PREFIX}/lib/ \;
-done
-
-# Verify libraries exist in PREFIX/lib
-ls -la ${PREFIX}/lib/lib*.so*

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,11 +4,13 @@ set -e -x
 # Get meson to find pkg-config when cross compiling
 export PKG_CONFIG="${BUILD_PREFIX}/bin/pkg-config"
 
-# Set PREFIX explicitly for installation
-export PREFIX_PATH="${PREFIX}"
-
 meson setup builddir \
     ${MESON_ARGS} \
+    --buildtype=release \
+    --prefix="$PREFIX" \
+    --libdir="${PREFIX}/lib" \
+    --includedir=${PREFIX}/include \
+    --backend=ninja \
     -Dasm=enabled \
     -Dx11=enabled \
     -Degl=true \
@@ -17,8 +19,7 @@ meson setup builddir \
     -Dgles2=true \
     -Dtls=true \
     -Ddispatch-tls=true \
-    -Dheaders=true \
-    --prefix=${PREFIX_PATH}
+    -Dheaders=true
 
 ninja -v -C builddir
 ninja -C builddir install

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -4,6 +4,9 @@ set -e -x
 # Get meson to find pkg-config when cross compiling
 export PKG_CONFIG="${BUILD_PREFIX}/bin/pkg-config"
 
+# Set PREFIX explicitly for installation
+export PREFIX_PATH="${PREFIX}"
+
 meson setup builddir \
     ${MESON_ARGS} \
     -Dasm=enabled \
@@ -14,7 +17,18 @@ meson setup builddir \
     -Dgles2=true \
     -Dtls=true \
     -Ddispatch-tls=true \
-    -Dheaders=true
+    -Dheaders=true \
+    --prefix=${PREFIX_PATH}
 
 ninja -v -C builddir
 ninja -C builddir install
+
+# Verify libraries were built and manually copy if needed
+mkdir -p ${PREFIX}/lib
+for lib in libGLX.so libOpenGL.so libGL.so libEGL.so libGLESv1_CM.so libGLESv2.so libGLdispatch.so; do
+    find builddir -name "${lib}*" -exec ls -la {} \;
+    find builddir -name "${lib}.*" -exec cp -av {} ${PREFIX}/lib/ \;
+done
+
+# Verify libraries exist in PREFIX/lib
+ls -la ${PREFIX}/lib/lib*.so*

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,6 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
-    - {{ stdlib('c') }}
     - meson
     - pkg-config
     - ninja
@@ -32,7 +31,6 @@ outputs:
       - "lib/libGLdispatch.so.*"
     requirements:
       build:
-        - {{ stdlib('c') }}
     test:
       commands:
         # Shared libraries (change in any SOVER means we need to react on run-export)
@@ -47,8 +45,6 @@ outputs:
       run_exports:
         - {{ pin_subpackage('libglvnd', max_pin='x') }}
     requirements:
-      build:
-        - {{ stdlib('c') }}
       host:
         - {{ pin_subpackage('libglvnd', exact=True) }}
       run:
@@ -66,8 +62,6 @@ outputs:
     files:
       - "lib/libOpenGL.so.*"
     requirements:
-      build:
-        - {{ stdlib('c') }}
       host:
         - {{ pin_subpackage('libglvnd', exact=True) }}
       run:
@@ -85,8 +79,6 @@ outputs:
       run_exports:
         - {{ pin_subpackage('libopengl', max_pin='x') }}
     requirements:
-      build:
-        - {{ stdlib('c') }}
       host:
         - {{ pin_subpackage('libopengl', exact=True) }}
       run:
@@ -101,8 +93,6 @@ outputs:
     files:
       - "lib/libGLX.so.*"
     requirements:
-      build:
-        - {{ stdlib('c') }}
       host:
         - {{ pin_subpackage('libglvnd', exact=True) }}
         - xorg-libx11
@@ -126,8 +116,6 @@ outputs:
         # Only need the headers during development build
         - xorg-libxext
     requirements:
-      build:
-        - {{ stdlib('c') }}
       host:
         - {{ pin_subpackage('libglx', exact=True) }}
         - xorg-libx11
@@ -148,8 +136,6 @@ outputs:
     files:
       - "lib/libGL.so.*"
     requirements:
-      build:
-        - {{ stdlib('c') }}
       host:
         - {{ pin_subpackage('libglvnd', exact=True) }}
         - {{ pin_subpackage('libglx', exact=True) }}
@@ -173,8 +159,6 @@ outputs:
       run_exports:
         - {{ pin_subpackage('libgl', max_pin='x') }}
     requirements:
-      build:
-        - {{ stdlib('c') }}
       host:
         - {{ pin_subpackage('libgl', exact=True) }}
         - {{ pin_subpackage('libglx-devel', exact=True) }}
@@ -195,8 +179,6 @@ outputs:
     files:
       - "lib/libEGL.so.*"
     requirements:
-      build:
-        - {{ stdlib('c') }}
       host:
         - {{ pin_subpackage('libglvnd', exact=True) }}
       run:
@@ -219,8 +201,6 @@ outputs:
         - libgl-devel
         - xorg-libx11
     requirements:
-      build:
-        - {{ stdlib('c') }}
       host:
         - {{ pin_subpackage('libegl', exact=True) }}
         - {{ pin_subpackage('libgl-devel', exact=True) }}
@@ -243,8 +223,6 @@ outputs:
       - "lib/libGLESv1_CM.so.*"
       - "lib/libGLESv2.so.*"
     requirements:
-      build:
-        - {{ stdlib('c') }}
       host:
         - {{ pin_subpackage('libglvnd', exact=True) }}
       run:
@@ -272,8 +250,6 @@ outputs:
         - libegl-devel
         - libgl-devel
     requirements:
-      build:
-        - {{ stdlib('c') }}
       host:
         - {{ pin_subpackage('libgles', exact=True) }}
         - {{ pin_subpackage('libegl-devel', exact=True) }}
@@ -303,9 +279,17 @@ outputs:
 
 about:
   home: https://gitlab.freedesktop.org/glvnd/libglvnd
+  dev_url: https://gitlab.freedesktop.org/glvnd/libglvnd
+  doc_url: https://gitlab.freedesktop.org/glvnd/libglvnd
   license: LicenseRef-libglvnd
   license_file: README.md
   summary: GL Vendor-Neutral Dispatch library
+  description: |
+    libglvnd is a vendor-neutral dispatch layer for arbitrating OpenGL API calls
+    between multiple vendors. It allows multiple drivers from different vendors to
+    coexist on the same filesystem, and determines which vendor to dispatch each
+    API call to at runtime.
+    Both GLX and EGL are supported, in any combination with OpenGL and OpenGL ES.
 
 extra:
   feedstock-name: libglvnd

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ outputs:
       - "lib/libGLdispatch.so.*"
     requirements:
       build:
+        - {{ compiler('c') }}
     test:
       commands:
         # Shared libraries (change in any SOVER means we need to react on run-export)
@@ -45,6 +46,8 @@ outputs:
       run_exports:
         - {{ pin_subpackage('libglvnd', max_pin='x') }}
     requirements:
+      build:
+        - {{ compiler('c') }}
       host:
         - {{ pin_subpackage('libglvnd', exact=True) }}
       run:
@@ -62,6 +65,8 @@ outputs:
     files:
       - "lib/libOpenGL.so.*"
     requirements:
+      build:
+        - {{ compiler('c') }}
       host:
         - {{ pin_subpackage('libglvnd', exact=True) }}
       run:
@@ -79,6 +84,8 @@ outputs:
       run_exports:
         - {{ pin_subpackage('libopengl', max_pin='x') }}
     requirements:
+      build:
+        - {{ compiler('c') }}
       host:
         - {{ pin_subpackage('libopengl', exact=True) }}
       run:
@@ -93,6 +100,8 @@ outputs:
     files:
       - "lib/libGLX.so.*"
     requirements:
+      build:
+        - {{ compiler('c') }}
       host:
         - {{ pin_subpackage('libglvnd', exact=True) }}
         - xorg-libx11
@@ -116,6 +125,8 @@ outputs:
         # Only need the headers during development build
         - xorg-libxext
     requirements:
+      build:
+        - {{ compiler('c') }}
       host:
         - {{ pin_subpackage('libglx', exact=True) }}
         - xorg-libx11
@@ -136,6 +147,8 @@ outputs:
     files:
       - "lib/libGL.so.*"
     requirements:
+      build:
+        - {{ compiler('c') }}
       host:
         - {{ pin_subpackage('libglvnd', exact=True) }}
         - {{ pin_subpackage('libglx', exact=True) }}
@@ -159,6 +172,8 @@ outputs:
       run_exports:
         - {{ pin_subpackage('libgl', max_pin='x') }}
     requirements:
+      build:
+        - {{ compiler('c') }}
       host:
         - {{ pin_subpackage('libgl', exact=True) }}
         - {{ pin_subpackage('libglx-devel', exact=True) }}
@@ -179,6 +194,8 @@ outputs:
     files:
       - "lib/libEGL.so.*"
     requirements:
+      build:
+        - {{ compiler('c') }}
       host:
         - {{ pin_subpackage('libglvnd', exact=True) }}
       run:
@@ -201,6 +218,8 @@ outputs:
         - libgl-devel
         - xorg-libx11
     requirements:
+      build:
+        - {{ compiler('c') }}
       host:
         - {{ pin_subpackage('libegl', exact=True) }}
         - {{ pin_subpackage('libgl-devel', exact=True) }}
@@ -223,6 +242,8 @@ outputs:
       - "lib/libGLESv1_CM.so.*"
       - "lib/libGLESv2.so.*"
     requirements:
+      build:
+        - {{ compiler('c') }}
       host:
         - {{ pin_subpackage('libglvnd', exact=True) }}
       run:
@@ -250,6 +271,8 @@ outputs:
         - libegl-devel
         - libgl-devel
     requirements:
+      build:
+        - {{ compiler('c') }}
       host:
         - {{ pin_subpackage('libgles', exact=True) }}
         - {{ pin_subpackage('libegl-devel', exact=True) }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,6 +17,7 @@ build:
 requirements:
   build:
     - {{ compiler('c') }}
+    - patch  # [unix]
     - meson
     - pkg-config
     - ninja
@@ -305,6 +306,7 @@ about:
   dev_url: https://gitlab.freedesktop.org/glvnd/libglvnd
   doc_url: https://gitlab.freedesktop.org/glvnd/libglvnd
   license: LicenseRef-libglvnd
+  license_family: Other
   license_file: README.md
   summary: GL Vendor-Neutral Dispatch library
   description: |


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-8128](https://anaconda.atlassian.net/browse/PKG-8128) 
- [Upstream repository](https://gitlab.freedesktop.org/glvnd/libglvnd)

### Explanation of changes:

- A new feedstock forked from conda-forge
- Add a few `meson` flags explicitly 
- Add `patch` to `build` explicitly
- Replace `{{ stdlib('c') }} `with `{{ compiler('c') }}` in every outputs' `requirements.build` sections, otherwise C standard libs can't be found
- Add dev & doc urls
- Add `description`

### Notes:

-

[PKG-8128]: https://anaconda.atlassian.net/browse/PKG-8128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ